### PR TITLE
fix: wrapped mountChainlitWidget in try-catch for error handling

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,22 +5,26 @@ window.addEventListener("chainlit-call-fn", (e) => {
     callback("You sent: " + args.msg);
 });
 
-
-window.mountChainlitWidget({
+try {
+  window.mountChainlitWidget({
     // URL of the Chainlit server
     chainlitServer: "https://muskan-fatima-agent.up.railway.app",
     // theme: "light" | "dark",
-    
+
     // Custom styling to apply to the widget button
     button: {
-        // ID of the container element to mount the button to
-        containerId: "copilot-chatbot",
-        // URL of the image to use as the button icon
-        imageUrl: "/assets/copilot-icon.png",
-        // The tailwind classname to apply to the button
-        className: "px-0 py-0 [&_svg]:size-1 bg-transparent hover:bg-transparent",
+      // ID of the container element to mount the button to
+      containerId: "copilot-chatbot",
+      // URL of the image to use as the button icon
+      imageUrl: "/assets/copilot-icon.png",
+      // The tailwind classname to apply to the button
+      className: "px-0 py-0 [&_svg]:size-1 bg-transparent hover:bg-transparent"
     }
-});
+  });
+} catch (error) {
+  console.log("Error occured while mounting Chainlit widget", error);
+}
+
 
 
 


### PR DESCRIPTION
# Fix: Wrapped mountChainlitWidget in try-catch for error handling
I found that the Chainlit server was down, and the script responsible for mounting it was placed globally without any error handling. As a result, further animations were failing to initiate due to the unhandled error. I resolved this issue by wrapping the mounting logic in a try-catch block, ensuring that the rest of the animations continue to work even if the server is unavailable.
## Screenshots
### Before
<img width="300" height="768" alt="Screenshot (368)" src="https://github.com/user-attachments/assets/367806dc-898b-42b2-9f66-007ccefa55e2" />
<img width="300" height="768" alt="Screenshot (369)" src="https://github.com/user-attachments/assets/dfc35ff7-7cae-4484-8f79-2704e6749f68" />

### After

<img width="300" height="768" alt="Screenshot (372)" src="https://github.com/user-attachments/assets/35f98ae4-93c2-4d4f-8057-58551053def1" />
<img width="300" height="768" alt="Screenshot (373)" src="https://github.com/user-attachments/assets/52475268-d16b-45fd-9ae6-b145f168b38f" />
