### PR TITLE
Fix: Navbar hamburger close button invisible on mobile screens (#16)

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <link rel="stylesheet" href="/src/index.css" />
     </head>
 
-    <body>
+    <body class="custom-scrollbar">
         <!-- Scroll to Top Button -->
         <button id="scrollToTop" class="scroll-to-top">
             <i class="fas fa-arrow-up"></i>
@@ -420,6 +420,7 @@
                                     name="message"
                                     rows="5"
                                     required
+                                    class="custom-scrollbar"
                                 ></textarea>
                                 <span
                                     class="error-message"

--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,19 @@
         background-color 0.3s ease,
         color 0.3s ease;
 }
+*::-webkit-scrollbar {
+    display: none;
+}
+.custom-scrollbar::-webkit-scrollbar {
+    display: block;
+    width: 0.25rem;
+    background-color: black;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--primary-light);
+    border-radius: 0.15rem;
+    cursor: pointer;
+}
 
 body {
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
@@ -578,6 +591,9 @@ section {
     transition: var(--transition);
     background-color: var(--white);
     color: var(--text-color);
+}
+textarea {
+    resize: none;
 }
 
 .form-group input:focus,

--- a/src/index.css
+++ b/src/index.css
@@ -229,6 +229,7 @@ nav {
 .hamburger {
     display: none;
     cursor: pointer;
+    z-index: 110;
 }
 
 .hamburger .line {

--- a/src/index.css
+++ b/src/index.css
@@ -347,6 +347,7 @@ nav {
     font-size: 1.1rem;
     transition: var(--transition);
     box-shadow: var(--shadow);
+    margin: 0.5rem;
 }
 
 .cta-button:hover {

--- a/src/main.js
+++ b/src/main.js
@@ -38,10 +38,32 @@ document.addEventListener("DOMContentLoaded", function () {
     const hamburger = document.querySelector(".hamburger");
     const navLinks = document.querySelector(".nav-links");
 
+    // outside click sidebar toggler
+    function toggleSidebarOnCLickOutside(evt) {
+        if (
+            evt.target !== navLinks &&
+            evt.target !== hamburger &&
+            !navLinks.contains(evt.target) &&
+            !hamburger.contains(evt.target)
+        ) {
+            hamburger.classList.toggle("active");
+            navLinks.classList.toggle("active");
+            document.removeEventListener("click", toggleSidebarOnCLickOutside);
+        }
+    }
+
     if (hamburger) {
         hamburger.addEventListener("click", () => {
             hamburger.classList.toggle("active");
             navLinks.classList.toggle("active");
+
+            // add event listener for click outside when sidebar is active
+            if (
+                hamburger.classList.contains("active") &&
+                navLinks.classList.contains("active")
+            ) {
+                document.addEventListener("click", toggleSidebarOnCLickOutside);
+            }
         });
     }
 


### PR DESCRIPTION
### Fixes #16 

- Fixes: sidebar hamburger z-index when sidebar is active 

- New: Added event listener to close sidebar when user clicks outside it

- New add custom scroll bar to body and textarea field